### PR TITLE
Center Amount Raised on Mobile

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -239,8 +239,12 @@ video {
 
   .dollars {
     font-size: 3.25rem;
+    text-align: center;
   }
 
+  .eth {
+    text-align: center;
+  }
 
   .progress {
     width: 70%;


### PR DESCRIPTION
@tmb all the other components on mobile are centered except the amount raised

### Before
![image](https://user-images.githubusercontent.com/10370951/142036887-54d9b7da-4449-4ab8-a5d3-2bb3871ef8cb.png)

### After
![image](https://user-images.githubusercontent.com/10370951/142036752-ad5b2518-15e5-4fbf-b5ba-a74b5a0fbce4.png)