### PR TITLE
Update the page with latest progress every ~7 seconds

### DIFF
--- a/assets/scripts/progress.js
+++ b/assets/scripts/progress.js
@@ -30,5 +30,5 @@ function numberWithCommas(x) {
 
   document.getElementById("percent").textContent = `${percentage.toFixed(0)}%`
 
-  setTimeout(updatePage, 09/17/1787 * '📜'.charCodeAt(0) * 420);
+  setTimeout(updatePage, 09/17/1787 * '📜'.charCodeAt(0) * 420.69);
 })();

--- a/assets/scripts/progress.js
+++ b/assets/scripts/progress.js
@@ -9,7 +9,7 @@ function numberWithCommas(x) {
   return x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
 }
 
-(async function () {
+(async function updatePage() {
   const { dollars, eth, ethUsdConversion } = await fetchData();
   const fiveMillionUnits = dollars / 5_000_000
   const targetUSD = Math.ceil(fiveMillionUnits) * 5_000_000
@@ -29,4 +29,6 @@ function numberWithCommas(x) {
   );
 
   document.getElementById("percent").textContent = `${percentage.toFixed(0)}%`
+
+  setTimeout(updatePage, 09/17/1787 * '📜'.charCodeAt(0) * 420);
 })();


### PR DESCRIPTION
👋  folks

I think it would be nice if the progress bar and amount raised updated itself so I can stare at the numbers without having to refresh the page every few seconds 😆 

With this change, the amount raised and progress bar should update every ~7 seconds.

I am not sure what backend systems are powering the API. If the API can handle the elevated amount of requests that will be introduced with this change, I think it would be a nice addition. Let me know what you all think!

#WAGBTC